### PR TITLE
Improve stroke replay fidelity and glass UI

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -1,5 +1,11 @@
 const canvas = document.getElementById('drawingCanvas');
 const ctx = canvas.getContext('2d');
+const analysisCanvas = document.getElementById('analysisCanvas');
+const analysisCtx = analysisCanvas ? analysisCanvas.getContext('2d') : null;
+if (analysisCanvas) {
+    analysisCanvas.width = canvas.width;
+    analysisCanvas.height = canvas.height;
+}
 const targetCharacterDiv = document.getElementById('targetCharacter');
 const feedbackDiv = document.getElementById('feedback');
 const scoreDiv = document.getElementById('score');
@@ -9,11 +15,46 @@ const colorPicker = document.getElementById('colorPicker');
 const lineWidth = document.getElementById('lineWidth');
 const submitButtonZh = document.getElementById('submitButtonZh');
 const submitButtonEn = document.getElementById('submitButtonEn');
+const coverageValue = document.getElementById('coverageValue');
+const precisionValue = document.getElementById('precisionValue');
+const gaugeProgress = document.getElementById('gaugeProgress');
+const gaugeLabel = document.getElementById('gaugeLabel');
+const toggleOverlayButton = document.getElementById('toggleOverlay');
+const analysisSummary = document.getElementById('analysisSummary');
+const replayButton = document.getElementById('replayButton');
+const bestAccuracyValue = document.getElementById('bestAccuracyValue');
+const averageAccuracyValue = document.getElementById('averageAccuracyValue');
+const attemptCountValue = document.getElementById('attemptCountValue');
+const streakValue = document.getElementById('streakValue');
+const sessionStatsContainer = document.getElementById('sessionStats');
 
 let drawing = false;
-let points = [];
-let lastPoint = null;
 const strokeHistory = [];
+let activeStroke = null;
+let lastEvaluation = null;
+let overlayVisible = false;
+let liveEvaluationScheduled = false;
+let isReplaying = false;
+let replayAnimationId = null;
+let replayTimeoutId = null;
+let replayState = null;
+
+const STATS_STORAGE_KEY = 'sir-drawing-practice-stats-v1';
+const ACCURACY_STREAK_THRESHOLD = 70;
+const REPLAY_STROKE_DELAY = 140;
+const REPLAY_DOT_HOLD = 220;
+const MIN_REPLAY_SEGMENT_DURATION = 16;
+
+const DEFAULT_SESSION_STATS = {
+    attempts: 0,
+    totalScore: 0,
+    bestScore: 0,
+    lastScore: 0,
+    currentStreak: 0,
+    bestStreak: 0
+};
+
+let sessionStats = { ...DEFAULT_SESSION_STATS };
 
 // Initialize canvas settings
 ctx.strokeStyle = colorPicker.value;
@@ -28,6 +69,431 @@ colorPicker.addEventListener('change', () => {
 lineWidth.addEventListener('change', () => {
     ctx.lineWidth = lineWidth.value;
 });
+
+const GAUGE_CIRCUMFERENCE = 2 * Math.PI * 52;
+
+function clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
+}
+
+function formatPercentDisplay(value) {
+    const number = Number.isFinite(value) ? value : 0;
+    const normalized = clamp(number, 0, 100);
+    if (Math.abs(normalized - Math.round(normalized)) < 0.05) {
+        return `${Math.round(normalized)}%`;
+    }
+    return `${normalized.toFixed(1)}%`;
+}
+
+function loadSessionStats() {
+    const defaults = { ...DEFAULT_SESSION_STATS };
+    if (typeof localStorage === 'undefined') {
+        return { ...defaults };
+    }
+    try {
+        const stored = localStorage.getItem(STATS_STORAGE_KEY);
+        if (!stored) {
+            return { ...defaults };
+        }
+        const parsed = JSON.parse(stored);
+        return { ...defaults, ...parsed };
+    } catch (error) {
+        console.warn('Unable to load practice stats:', error);
+        return { ...defaults };
+    }
+}
+
+function saveSessionStats() {
+    if (typeof localStorage === 'undefined') {
+        return;
+    }
+    try {
+        localStorage.setItem(STATS_STORAGE_KEY, JSON.stringify(sessionStats));
+    } catch (error) {
+        console.warn('Unable to save practice stats:', error);
+    }
+}
+
+function updateSessionStatsUI() {
+    if (!bestAccuracyValue || !averageAccuracyValue || !attemptCountValue || !streakValue) {
+        return;
+    }
+
+    const attempts = Number(sessionStats.attempts) || 0;
+    const average = attempts ? sessionStats.totalScore / attempts : 0;
+    const best = clamp(Number(sessionStats.bestScore) || 0, 0, 100);
+    const currentStreak = Number(sessionStats.currentStreak) || 0;
+    const bestStreak = Number(sessionStats.bestStreak) || 0;
+
+    bestAccuracyValue.textContent = formatPercentDisplay(best);
+    averageAccuracyValue.textContent = formatPercentDisplay(average);
+    attemptCountValue.textContent = attempts.toString();
+    streakValue.textContent = `${currentStreak} / ${bestStreak}`;
+
+    if (sessionStatsContainer) {
+        sessionStatsContainer.classList.toggle('is-empty', attempts === 0);
+        const placeholders = sessionStatsContainer.querySelectorAll('.session-stats-placeholder');
+        placeholders.forEach(node => {
+            node.classList.toggle('active', attempts === 0);
+        });
+    }
+}
+
+function recordAttempt(score) {
+    const safeScore = clamp(Number(score) || 0, 0, 100);
+    sessionStats.attempts += 1;
+    sessionStats.totalScore += safeScore;
+    sessionStats.lastScore = safeScore;
+    sessionStats.bestScore = Math.max(sessionStats.bestScore, safeScore);
+
+    if (safeScore >= ACCURACY_STREAK_THRESHOLD) {
+        sessionStats.currentStreak += 1;
+        sessionStats.bestStreak = Math.max(sessionStats.bestStreak, sessionStats.currentStreak);
+    } else {
+        sessionStats.currentStreak = 0;
+    }
+
+    saveSessionStats();
+    updateSessionStatsUI();
+}
+
+function updateReplayButtonLabel() {
+    if (!replayButton) return;
+    const isEnglish = document.documentElement.lang === 'en';
+    const label = replayButton.dataset[isEnglish ? 'labelEn' : 'labelZh'];
+    if (label) {
+        replayButton.textContent = label;
+    }
+}
+
+function updateGauge(score) {
+    const safeScore = clamp(score, 0, 100);
+    const offset = GAUGE_CIRCUMFERENCE * (1 - safeScore / 100);
+    gaugeProgress.style.strokeDashoffset = offset.toFixed(2);
+    gaugeLabel.textContent = `${Math.round(safeScore)}%`;
+}
+
+function updateMetrics({ precision = 0, recall = 0 } = {}) {
+    const coveragePercent = Math.round(clamp(recall, 0, 1) * 100);
+    const precisionPercent = Math.round(clamp(precision, 0, 1) * 100);
+    coverageValue.textContent = `${coveragePercent}%`;
+    precisionValue.textContent = `${precisionPercent}%`;
+}
+
+function updateScoreText(value = 0) {
+    scoreDiv.dataset.score = value;
+    const isEnglish = document.documentElement.lang === 'en';
+    scoreDiv.textContent = isEnglish ? `Score: ${Math.round(value)}%` : `得分: ${Math.round(value)}%`;
+}
+
+function updateAnalysisSummary(evaluation) {
+    if (!analysisSummary || !toggleOverlayButton) return;
+    if (!evaluation) {
+        analysisSummary.textContent = '';
+        return;
+    }
+
+    const hasInk = strokeHistory.length > 0;
+    if (!hasInk) {
+        analysisSummary.textContent = '';
+        return;
+    }
+
+    const missingPercent = evaluation.refPixelCount === 0 ? 0 : (evaluation.missingCount / evaluation.refPixelCount) * 100;
+    const extraPercent = evaluation.userPixelCount === 0 ? 0 : (evaluation.extraCount / Math.max(1, evaluation.userPixelCount)) * 100;
+
+    const formatPercent = (value) => {
+        if (value === 0) return '0';
+        return value >= 10 ? Math.round(value).toString() : value.toFixed(1);
+    };
+
+    const missingText = formatPercent(missingPercent);
+    const extraText = formatPercent(extraPercent);
+    const isEnglish = document.documentElement.lang === 'en';
+
+    if (missingPercent < 1 && extraPercent < 1) {
+        analysisSummary.textContent = isEnglish ?
+            'Perfect alignment — every stroke matches the guide!' :
+            '完美對齊，筆劃完全貼住樣板！';
+        return;
+    }
+
+    const promptEn = overlayVisible ? toggleOverlayButton.dataset.hideLabelEn : toggleOverlayButton.dataset.labelEn;
+    const promptZh = overlayVisible ? toggleOverlayButton.dataset.hideLabelZh : toggleOverlayButton.dataset.labelZh;
+
+    analysisSummary.textContent = isEnglish ?
+        `Uncovered guide area: ~${missingText}% · stray ink: ~${extraText}%. Tap “${promptEn}” to inspect.` :
+        `未覆蓋樣板：約 ${missingText}% · 多餘線條：約 ${extraText}%。點「${promptZh}」睇提示。`;
+}
+
+function updateToggleOverlayLabel() {
+    if (!toggleOverlayButton) return;
+    const isEnglish = document.documentElement.lang === 'en';
+    const showLabel = toggleOverlayButton.dataset[isEnglish ? 'labelEn' : 'labelZh'];
+    const hideLabel = toggleOverlayButton.dataset[isEnglish ? 'hideLabelEn' : 'hideLabelZh'];
+    toggleOverlayButton.textContent = overlayVisible ? hideLabel : showLabel;
+}
+
+function updateOverlayVisibility() {
+    if (!analysisCanvas) return;
+    analysisCanvas.classList.toggle('visible', overlayVisible);
+    updateToggleOverlayLabel();
+}
+
+function updateGuidanceAvailability() {
+    const hasStrokes = strokeHistory.length > 0;
+    if (toggleOverlayButton) {
+        toggleOverlayButton.disabled = !hasStrokes || isReplaying;
+    }
+    if (replayButton) {
+        replayButton.disabled = !hasStrokes || isReplaying;
+    }
+    if (!hasStrokes) {
+        overlayVisible = false;
+        updateOverlayVisibility();
+    }
+}
+
+function clearAnalysisOverlay() {
+    if (!analysisCtx) return;
+    analysisCtx.clearRect(0, 0, analysisCanvas.width, analysisCanvas.height);
+}
+
+function renderAnalysisOverlay(evaluation) {
+    if (!analysisCtx) return;
+    if (!evaluation) {
+        clearAnalysisOverlay();
+        return;
+    }
+
+    const { width, height, refMask, userMask } = evaluation;
+    if (analysisCanvas.width !== width || analysisCanvas.height !== height) {
+        analysisCanvas.width = width;
+        analysisCanvas.height = height;
+    }
+    const imageData = analysisCtx.createImageData(width, height);
+    const data = imageData.data;
+
+    for (let i = 0; i < refMask.length; i++) {
+        const ref = refMask[i];
+        const user = userMask[i];
+        const index = i * 4;
+
+        if (ref && user) {
+            data[index] = 46;
+            data[index + 1] = 204;
+            data[index + 2] = 113;
+            data[index + 3] = 180;
+        } else if (ref) {
+            data[index] = 231;
+            data[index + 1] = 76;
+            data[index + 2] = 60;
+            data[index + 3] = 200;
+        } else if (user) {
+            data[index] = 52;
+            data[index + 1] = 152;
+            data[index + 2] = 219;
+            data[index + 3] = 180;
+        } else {
+            data[index + 3] = 0;
+        }
+    }
+
+    analysisCtx.putImageData(imageData, 0, 0);
+}
+
+function setReplayActive(active) {
+    isReplaying = active;
+    canvas.classList.toggle('is-replaying', active);
+    [submitButtonZh, submitButtonEn, undoButton, resetButton].forEach(button => {
+        if (!button) return;
+        button.disabled = active;
+    });
+
+    if (analysisCanvas) {
+        analysisCanvas.classList.toggle('replay-hidden', active);
+    }
+
+    if (!active) {
+        [submitButtonZh, submitButtonEn, undoButton, resetButton].forEach(button => {
+            if (!button) return;
+            button.disabled = false;
+        });
+        updateGuidanceAvailability();
+    } else {
+        if (toggleOverlayButton) {
+            toggleOverlayButton.disabled = true;
+        }
+        if (replayButton) {
+            replayButton.disabled = true;
+        }
+    }
+}
+
+function finishReplay({ restore = true } = {}) {
+    if (replayAnimationId) {
+        cancelAnimationFrame(replayAnimationId);
+        replayAnimationId = null;
+    }
+    if (replayTimeoutId) {
+        clearTimeout(replayTimeoutId);
+        replayTimeoutId = null;
+    }
+
+    if (replayState && replayState.originalStyle) {
+        ctx.strokeStyle = replayState.originalStyle.color;
+        ctx.lineWidth = replayState.originalStyle.lineWidth;
+    }
+    replayState = null;
+
+    if (restore) {
+        redrawCanvas();
+    }
+
+    setReplayActive(false);
+}
+
+function cancelReplay({ restore = true } = {}) {
+    if (!isReplaying && !replayState) return;
+    finishReplay({ restore });
+}
+
+function replayDrawing() {
+    if (isReplaying || !strokeHistory.length) return;
+
+    const timeline = prepareReplayTimeline();
+    replayState = {
+        originalStyle: {
+            color: ctx.strokeStyle,
+            lineWidth: ctx.lineWidth
+        },
+        timeline,
+        strokeIndex: 0,
+        lastTimestamp: null
+    };
+
+    setReplayActive(true);
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    const step = (timestamp) => {
+        if (!isReplaying || !replayState) {
+            return;
+        }
+
+        if (replayState.strokeIndex >= replayState.timeline.length) {
+            finishReplay({ restore: true });
+            return;
+        }
+
+        if (replayState.lastTimestamp === null) {
+            replayState.lastTimestamp = timestamp;
+        }
+
+        let delta = timestamp - replayState.lastTimestamp;
+        replayState.lastTimestamp = timestamp;
+
+        while (replayState.strokeIndex < replayState.timeline.length) {
+            const stroke = replayState.timeline[replayState.strokeIndex];
+            if (!stroke.points || !stroke.points.length) {
+                replayState.strokeIndex += 1;
+                continue;
+            }
+
+            ctx.strokeStyle = stroke.color;
+            ctx.lineWidth = stroke.width;
+            ctx.lineCap = 'round';
+            ctx.lineJoin = 'round';
+
+            if (stroke.isDot) {
+                const point = stroke.points[0];
+                ctx.beginPath();
+                ctx.arc(point.x, point.y, stroke.width / 2, 0, Math.PI * 2);
+                ctx.fillStyle = stroke.color;
+                ctx.fill();
+                replayState.strokeIndex += 1;
+                replayState.lastTimestamp = null;
+                replayTimeoutId = setTimeout(() => {
+                    replayAnimationId = requestAnimationFrame(step);
+                }, REPLAY_STROKE_DELAY + REPLAY_DOT_HOLD);
+                return;
+            }
+
+            let advancedSegment = false;
+
+            while (stroke.pointIndex < stroke.points.length) {
+                const duration = stroke.durations[stroke.pointIndex] || MIN_REPLAY_SEGMENT_DURATION;
+                const remaining = duration - stroke.progress;
+                const from = stroke.points[stroke.pointIndex - 1];
+                const to = stroke.points[stroke.pointIndex];
+
+                if (delta < remaining) {
+                    stroke.progress += delta;
+                    const t = stroke.progress / duration;
+                    const currentX = from.x + (to.x - from.x) * t;
+                    const currentY = from.y + (to.y - from.y) * t;
+                    ctx.beginPath();
+                    ctx.moveTo(from.x, from.y);
+                    ctx.lineTo(currentX, currentY);
+                    ctx.stroke();
+                    replayAnimationId = requestAnimationFrame(step);
+                    return;
+                }
+
+                ctx.beginPath();
+                ctx.moveTo(from.x, from.y);
+                ctx.lineTo(to.x, to.y);
+                ctx.stroke();
+                stroke.pointIndex += 1;
+                stroke.progress = 0;
+                delta -= remaining;
+                advancedSegment = true;
+            }
+
+            if (stroke.pointIndex >= stroke.points.length) {
+                replayState.strokeIndex += 1;
+                replayState.lastTimestamp = null;
+                replayTimeoutId = setTimeout(() => {
+                    replayAnimationId = requestAnimationFrame(step);
+                }, REPLAY_STROKE_DELAY);
+                return;
+            }
+
+            if (!advancedSegment) {
+                break;
+            }
+        }
+
+        finishReplay({ restore: true });
+    };
+
+    replayAnimationId = requestAnimationFrame(step);
+}
+
+function applyEvaluation(evaluation, { final = false } = {}) {
+    if (!evaluation) return;
+    lastEvaluation = { ...evaluation };
+    updateGauge(evaluation.score);
+    updateMetrics(evaluation);
+    updateAnalysisSummary(evaluation);
+
+    if (overlayVisible) {
+        renderAnalysisOverlay(evaluation);
+    } else if (final) {
+        // Prepare overlay for when the user opens it later
+        renderAnalysisOverlay(evaluation);
+    }
+}
+
+function scheduleScoreUpdate() {
+    if (isReplaying) return;
+    if (liveEvaluationScheduled) return;
+    liveEvaluationScheduled = true;
+    requestAnimationFrame(() => {
+        const evaluation = calculateScore();
+        applyEvaluation(evaluation, { final: false });
+        liveEvaluationScheduled = false;
+    });
+}
 
 // Set target character
 const targetCharacter = `                                                                                       
@@ -70,20 +536,6 @@ function getMousePos(canvas, evt) {
     };
 }
 
-function startDrawing(e) {
-    drawing = true;
-    points = [];
-    const pos = getMousePos(canvas, e);
-    lastPoint = pos;
-    ctx.beginPath();
-    ctx.moveTo(pos.x, pos.y);
-}
-
-// Add stroke smoothing variables
-let smoothedPoints = [];
-const smoothingFactor = 0.2;
-
-// Helper function to get touch position
 function getTouchPos(canvas, evt) {
     const rect = canvas.getBoundingClientRect();
     const scaleX = canvas.width / rect.width;
@@ -94,88 +546,185 @@ function getTouchPos(canvas, evt) {
     };
 }
 
-// Smoothing function
-function smoothPoints(points) {
-    if (points.length < 3) return points;
-    
+function startStrokeAt(position) {
+    drawing = true;
+    const startTime = performance.now();
+    activeStroke = {
+        color: ctx.strokeStyle,
+        width: Number(ctx.lineWidth) || 1,
+        startTime,
+        points: [{ x: position.x, y: position.y, time: 0 }]
+    };
+}
+
+function appendStrokePoint(position) {
+    if (!activeStroke) return;
+    const now = performance.now();
+    const elapsed = now - activeStroke.startTime;
+    activeStroke.points.push({ x: position.x, y: position.y, time: elapsed });
+    const smoothedPoints = smoothStrokePoints(activeStroke.points);
+    redrawCanvas();
+    renderStroke(ctx, {
+        color: activeStroke.color,
+        width: activeStroke.width,
+        points: smoothedPoints
+    });
+}
+
+function finalizeStroke() {
+    if (!activeStroke || !activeStroke.points.length) {
+        activeStroke = null;
+        drawing = false;
+        return;
+    }
+
+    const smoothedPoints = smoothStrokePoints(activeStroke.points);
+    const normalizedPoints = smoothedPoints.map(point => ({
+        x: point.x,
+        y: point.y,
+        time: point.time ?? 0
+    }));
+
+    const strokeEntry = {
+        color: activeStroke.color,
+        width: activeStroke.width,
+        points: normalizedPoints,
+        isDot: normalizedPoints.length === 1
+    };
+
+    strokeHistory.push(strokeEntry);
+    redrawCanvas();
+    drawing = false;
+    activeStroke = null;
+    if (strokeHistory.length) {
+        scheduleScoreUpdate();
+    }
+    updateGuidanceAvailability();
+}
+
+function startDrawing(e) {
+    if (isReplaying) {
+        cancelReplay();
+    }
+    const pos = getMousePos(canvas, e);
+    ctx.beginPath();
+    ctx.moveTo(pos.x, pos.y);
+    startStrokeAt(pos);
+}
+
+function smoothStrokePoints(points) {
+    if (points.length < 3) {
+        return points.map(point => ({ ...point }));
+    }
+
     const smoothed = [];
-    smoothed.push(points[0]);
-    
+    smoothed.push({ ...points[0] });
+
     for (let i = 1; i < points.length - 1; i++) {
         const prevPoint = points[i - 1];
         const currentPoint = points[i];
         const nextPoint = points[i + 1];
-        
+
         const smoothedX = currentPoint.x + smoothingFactor * (
             (prevPoint.x + nextPoint.x) / 2 - currentPoint.x
         );
         const smoothedY = currentPoint.y + smoothingFactor * (
             (prevPoint.y + nextPoint.y) / 2 - currentPoint.y
         );
-        
-        smoothed.push({ x: smoothedX, y: smoothedY });
+
+        smoothed.push({ x: smoothedX, y: smoothedY, time: currentPoint.time });
     }
-    
-    smoothed.push(points[points.length - 1]);
+
+    const lastPoint = points[points.length - 1];
+    smoothed.push({ ...lastPoint });
     return smoothed;
 }
 
-// Modified draw function with smoothing
-function draw(e) {
-    if (!drawing) return;
-    e.preventDefault();
-    
-    const pos = e.type.includes('touch') ? getTouchPos(canvas, e) : getMousePos(canvas, e);
-    points.push(pos);
-    
-    // Apply smoothing if we have enough points
-    if (points.length > 2) {
-        smoothedPoints = smoothPoints(points);
-        
-        // Clear the previous line segment
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
-        
-        // Redraw all previous strokes
-        strokeHistory.forEach(stroke => {
-            if (stroke.length > 0) {
-                ctx.beginPath();
-                ctx.moveTo(stroke[0].x, stroke[0].y);
-                stroke.forEach(point => ctx.lineTo(point.x, point.y));
-                ctx.stroke();
-            }
+function prepareReplayTimeline() {
+    return strokeHistory.map(stroke => {
+        const durations = stroke.points.map((point, index) => {
+            if (index === 0) return 0;
+            const previous = stroke.points[index - 1];
+            const prevTime = previous.time ?? 0;
+            const currentTime = point.time ?? 0;
+            return Math.max(MIN_REPLAY_SEGMENT_DURATION, currentTime - prevTime);
         });
-        
-        // Draw current stroke
-        ctx.beginPath();
-        ctx.moveTo(smoothedPoints[0].x, smoothedPoints[0].y);
-        for (let i = 1; i < smoothedPoints.length; i++) {
-            ctx.lineTo(smoothedPoints[i].x, smoothedPoints[i].y);
-        }
-        ctx.stroke();
-    }
+
+        return {
+            color: stroke.color,
+            width: stroke.width,
+            points: stroke.points.map(point => ({ x: point.x, y: point.y })),
+            durations,
+            pointIndex: 1,
+            progress: 0,
+            isDot: stroke.isDot || stroke.points.length === 1
+        };
+    });
 }
 
-// Modified stop drawing function
-function stopDrawing() {
-    if (!drawing) return;
-    drawing = false;
-    if (points.length > 0) {
-        strokeHistory.push(smoothedPoints.length > 0 ? [...smoothedPoints] : [...points]);
+function renderStroke(targetCtx, stroke) {
+    if (!stroke || !stroke.points || stroke.points.length === 0) return;
+    targetCtx.save();
+    targetCtx.strokeStyle = stroke.color;
+    targetCtx.lineWidth = stroke.width;
+    targetCtx.lineCap = 'round';
+    targetCtx.lineJoin = 'round';
+    if (stroke.points.length === 1) {
+        const point = stroke.points[0];
+        targetCtx.beginPath();
+        targetCtx.arc(point.x, point.y, stroke.width / 2, 0, Math.PI * 2);
+        targetCtx.fillStyle = stroke.color;
+        targetCtx.fill();
+    } else {
+        targetCtx.beginPath();
+        targetCtx.moveTo(stroke.points[0].x, stroke.points[0].y);
+        for (let i = 1; i < stroke.points.length; i++) {
+            targetCtx.lineTo(stroke.points[i].x, stroke.points[i].y);
+        }
+        targetCtx.stroke();
     }
-    points = [];
-    smoothedPoints = [];
+    targetCtx.restore();
+}
+
+function redrawCanvas() {
+    const activeColor = ctx.strokeStyle;
+    const activeWidth = ctx.lineWidth;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    strokeHistory.forEach(stroke => renderStroke(ctx, stroke));
+    ctx.strokeStyle = activeColor;
+    ctx.lineWidth = activeWidth;
+}
+
+function draw(e) {
+    if (!drawing || isReplaying || !activeStroke) return;
+    if (e && typeof e.preventDefault === 'function' && e.cancelable) {
+        e.preventDefault();
+    }
+
+    const pos = e.type.includes('touch') ? getTouchPos(canvas, e) : getMousePos(canvas, e);
+    appendStrokePoint(pos);
+}
+
+function stopDrawing(e) {
+    if (!drawing) return;
+    if (e && typeof e.preventDefault === 'function' && e.cancelable) {
+        e.preventDefault();
+    }
+    finalizeStroke();
 }
 
 // Add touch event listeners
 canvas.addEventListener('touchstart', (e) => {
-    e.preventDefault();
-    drawing = true;
-    points = [];
-    smoothedPoints = [];
+    if (e.cancelable) {
+        e.preventDefault();
+    }
+    if (isReplaying) {
+        cancelReplay();
+    }
     const pos = getTouchPos(canvas, e);
-    lastPoint = pos;
     ctx.beginPath();
     ctx.moveTo(pos.x, pos.y);
+    startStrokeAt(pos);
 });
 
 canvas.addEventListener('touchmove', draw);
@@ -188,102 +737,6 @@ canvas.addEventListener('mousemove', draw);
 canvas.addEventListener('mouseup', stopDrawing);
 canvas.addEventListener('mouseout', stopDrawing);
 
-// Add these utility functions before calculateScore
-function preprocessCanvas(canvas) {
-    return tf.tidy(() => {
-        // Convert canvas to tensor
-        let tensor = tf.browser.fromPixels(canvas, 1);
-        
-        // Resize to 28x28
-        tensor = tf.image.resizeBilinear(tensor, [28, 28]);
-        
-        // Normalize values to [0, 1]
-        tensor = tensor.toFloat().div(tf.scalar(255));
-        
-        // Add batch dimension
-        return tensor.expandDims(0);
-    });
-}
-
-function aggregatePointsFromStrokeHistory(strokes) {
-    const allPoints = [];
-
-    // Draw user strokes
-    userCtx.fillStyle = 'white';
-    userCtx.fillRect(0, 0, canvas.width, canvas.height);
-    userCtx.strokeStyle = 'black';
-    userCtx.lineWidth = 3;
-    userCtx.lineCap = 'round';
-    userCtx.lineJoin = 'round';
-    
-    strokeHistory.forEach(stroke => {
-        if (stroke.length > 0) {
-            userCtx.beginPath();
-            userCtx.moveTo(stroke[0].x, stroke[0].y);
-            stroke.forEach(point => ctx.lineTo(point.x, point.y));
-            ctx.stroke();
-        }
-    });
-
-    // Get image data
-    const refData = refCtx.getImageData(0, 0, canvas.width, canvas.height).data;
-    const userData = userCtx.getImageData(0, 0, canvas.width, canvas.height).data;
-
-    let matchingPixels = 0;
-    let totalTargetPixels = 0;
-    let extraPixels = 0;
-    const tolerance = 8; // Increased tolerance
-
-    // Compare pixels with tolerance
-    for (let y = 0; y < canvas.height; y++) {
-        for (let x = 0; x < canvas.width; x++) {
-            const i = (y * canvas.width + x) * 4;
-            const isRefBlack = refData[i] < 200; // Relaxed threshold for black
-            const isUserBlack = userData[i] < 200;
-
-            if (isRefBlack) {
-                totalTargetPixels++;
-                // Check surrounding pixels
-                let matched = false;
-                for (let dy = -tolerance; dy <= tolerance && !matched; dy++) {
-                    for (let dx = -tolerance; dx <= tolerance && !matched; dx++) {
-                        const ni = ((y + dy) * canvas.width + (x + dx)) * 4;
-                        if (ni >= 0 && ni < userData.length && userData[ni] < 200) {
-                            matched = true;
-                            matchingPixels++;
-                        }
-                    }
-                }
-            } else if (isUserBlack) {
-                // Check if this black pixel is near any reference black pixel
-                let nearTarget = false;
-                for (let dy = -tolerance; dy <= tolerance && !nearTarget; dy++) {
-                    for (let dx = -tolerance; dx <= tolerance && !nearTarget; dx++) {
-                        const ni = ((y + dy) * canvas.width + (x + dx)) * 4;
-                        if (ni >= 0 && ni < refData.length && refData[ni] < 200) {
-                            nearTarget = true;
-                        }
-                    }
-                }
-                if (!nearTarget) {
-                    extraPixels++;
-                }
-            }
-        }
-    }
-
-    // Calculate weighted score with adjusted weights and scaling
-    const coverage = matchingPixels / (totalTargetPixels || 1);
-    const precision = 1 - (extraPixels / (totalTargetPixels || 1));
-    
-    // Adjust weights to emphasize coverage more than precision
-    const weightedScore = (coverage * 0.8 + Math.max(0, precision) * 0.2) * 100;
-
-    // Scale the score to make it more achievable
-    const scaledScore = Math.min(100, Math.max(0, weightedScore * 1.5));
-    
-    return scaledScore;
-}
 
 function getBoundingBox(points) {
     let minX = Infinity, minY = Infinity;
@@ -318,20 +771,20 @@ function getTargetBoundingBox() {
 function provideFeedback(score) {
     const isEnglish = document.documentElement.lang === 'en';
     if (score > 70) {
-        feedbackDiv.textContent = isEnglish ? 
+        feedbackDiv.textContent = isEnglish ?
             "Father-in-law: So 'sir' can be written like this! You learn something new every day!" :
             "親家老爺:原來個sir字都有得寫嘅 真係活到老 學到老 ";
-        feedbackDiv.style.color = "green";
+        feedbackDiv.style.color = "#0f766e";
     } else if (score > 50) {
         feedbackDiv.textContent = isEnglish ?
             "Father-in-law: Interesting way to write 'sir'!" :
             "親家老爺:原來個sir字都有得寫嘅 真係活到老 學到老 ";
-        feedbackDiv.style.color = "orange";
+        feedbackDiv.style.color = "#d97706";
     } else {
         feedbackDiv.textContent = isEnglish ?
             "So you're a police officer! 🔫" :
             "原來你係警察🔫!!！";
-        feedbackDiv.style.color = "red";
+        feedbackDiv.style.color = "#dc2626";
     }
 }
 
@@ -386,53 +839,97 @@ function showFailureEffect() {
 }
 
 function handleSubmit() {
-    calculateScore().then(score => {
-        const isEnglish = document.documentElement.lang === 'en';
-        scoreDiv.textContent = isEnglish ? `Score: ${score.toFixed(0)}%` : `得分: ${score.toFixed(0)}%`;
-        scoreDiv.classList.add('visible');
-        
-        if (score < 50) {
-            showFailureEffect();
-            feedbackDiv.textContent = isEnglish ? 
-                "So you're a police officer! 🔫" : 
-                "原來你係警察🔫!!！";
-            feedbackDiv.style.color = "#e74c3c";
-        } else {
-            showSuccessEffect();
-            provideFeedback(score);
-        }
-    });
+    cancelReplay();
+    const evaluation = calculateScore();
+    applyEvaluation(evaluation, { final: true });
+
+    const finalScore = evaluation.score;
+    updateScoreText(finalScore);
+    scoreDiv.classList.add('visible');
+
+    const isEnglish = document.documentElement.lang === 'en';
+
+    if (finalScore < 50) {
+        showFailureEffect();
+        feedbackDiv.textContent = isEnglish ?
+            "So you're a police officer! 🔫" :
+            "原來你係警察🔫!!！";
+        feedbackDiv.style.color = "#dc2626";
+    } else {
+        showSuccessEffect();
+        provideFeedback(finalScore);
+    }
+
+    recordAttempt(finalScore);
 }
 
 submitButtonZh.addEventListener('click', handleSubmit);
 submitButtonEn.addEventListener('click', handleSubmit);
 
 resetButton.addEventListener('click', () => {
+    cancelReplay({ restore: false });
     ctx.clearRect(0, 0, canvas.width, canvas.height);
-    points = [];
+    activeStroke = null;
+    drawing = false;
     strokeHistory.length = 0;
     feedbackDiv.textContent = "";
     scoreDiv.classList.remove('visible');
     const container = document.querySelector('.container');
     container.classList.remove('game-over');
-    const isEnglish = document.documentElement.lang === 'en';
-    scoreDiv.textContent = isEnglish ? 'Score: 0%' : '得分: 0%';
+    updateScoreText(0);
+    updateGauge(0);
+    updateMetrics({ precision: 0, recall: 0 });
+    lastEvaluation = null;
+    overlayVisible = false;
+    updateOverlayVisibility();
+    clearAnalysisOverlay();
+    updateAnalysisSummary(null);
+    updateGuidanceAvailability();
 });
 
 undoButton.addEventListener('click', () => {
+    cancelReplay();
     if (strokeHistory.length > 0) {
         strokeHistory.pop();
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
-        strokeHistory.forEach(stroke => {
-            ctx.beginPath();
-            ctx.moveTo(stroke[0].x, stroke[0].y);
-            stroke.forEach(point => {
-                ctx.lineTo(point.x, point.y);
-                ctx.stroke();
-            });
-        });
+        redrawCanvas();
+        if (strokeHistory.length) {
+            scheduleScoreUpdate();
+        } else {
+            updateScoreText(0);
+            updateGauge(0);
+            updateMetrics({ precision: 0, recall: 0 });
+            lastEvaluation = null;
+            clearAnalysisOverlay();
+            updateAnalysisSummary(null);
+        }
     }
+    updateGuidanceAvailability();
 });
+
+if (toggleOverlayButton) {
+    toggleOverlayButton.addEventListener('click', () => {
+        if (isReplaying) return;
+        if (!overlayVisible && !lastEvaluation && strokeHistory.length) {
+            const evaluation = calculateScore();
+            applyEvaluation(evaluation, { final: false });
+        }
+
+        overlayVisible = !overlayVisible;
+        if (overlayVisible) {
+            if (lastEvaluation) {
+                renderAnalysisOverlay(lastEvaluation);
+            } else {
+                clearAnalysisOverlay();
+            }
+        }
+        updateOverlayVisibility();
+        updateAnalysisSummary(lastEvaluation);
+    });
+}
+
+if (replayButton) {
+    replayButton.addEventListener('click', replayDrawing);
+}
 
 function toggleLanguage() {
     const currentLang = document.documentElement.lang;
@@ -449,12 +946,11 @@ function toggleLanguage() {
     });
 
     // Update score text based on language
-    const score = scoreDiv.textContent.match(/\d+/);
-    if (score) {
-        scoreDiv.textContent = newLang === 'en' ? `Score: ${score[0]}%` : `得分: ${score[0]}%`;
-    } else {
-        scoreDiv.textContent = newLang === 'en' ? 'Score: 0%' : '得分: 0%';
-    }
+    const storedScore = Number(scoreDiv.dataset.score || 0);
+    updateScoreText(storedScore);
+    updateToggleOverlayLabel();
+    updateReplayButtonLabel();
+    updateAnalysisSummary(lastEvaluation);
 }
 
 // Initialize language
@@ -462,131 +958,174 @@ document.addEventListener('DOMContentLoaded', () => {
     const userLang = navigator.language || navigator.userLanguage;
     const initialLang = userLang.startsWith('zh') ? 'zh' : 'en';
     document.documentElement.lang = initialLang;
-    
+
     // Update initial score text based on language
-    scoreDiv.textContent = initialLang === 'en' ? 'Score: 0%' : '得分: 0%';
-    
+    updateScoreText(0);
+    updateGauge(0);
+    updateMetrics({ precision: 0, recall: 0 });
+    updateToggleOverlayLabel();
+    updateReplayButtonLabel();
+    updateGuidanceAvailability();
+    updateAnalysisSummary(null);
+
     document.querySelectorAll(`[lang="${initialLang}"]`).forEach(el => {
         el.classList.add('active');
     });
+
+    try {
+        sessionStats = loadSessionStats();
+    } catch (error) {
+        console.warn('Falling back to default practice stats:', error);
+        sessionStats = { ...DEFAULT_SESSION_STATS };
+    }
+    updateSessionStatsUI();
 });
 
 // Replace the calculateScore function with this improved version
 function calculateScore() {
-    return new Promise((resolve) => {
-        const refCanvas = document.createElement('canvas');
-        const userCanvas = document.createElement('canvas');
-        refCanvas.width = userCanvas.width = canvas.width;
-        refCanvas.height = userCanvas.height = canvas.height;
-        const refCtx = refCanvas.getContext('2d');
-        const userCtx = userCanvas.getContext('2d');
+    const width = canvas.width;
+    const height = canvas.height;
+    const totalPixels = width * height;
 
-        // Draw reference pattern
-        refCtx.fillStyle = 'white';
-        refCtx.fillRect(0, 0, refCanvas.width, refCanvas.height);
-        refCtx.fillStyle = 'black';
-        const lines = targetCharacter.split('\n');
-        const cellHeight = refCanvas.height / lines.length;
-        const cellWidth = refCanvas.width / lines[0].length;
-        
-        lines.forEach((line, y) => {
-            [...line].forEach((char, x) => {
-                if (char === '#') {
-                    refCtx.fillRect(x * cellWidth, y * cellHeight, cellWidth, cellHeight);
-                }
-            });
-        });
+    const refCanvas = document.createElement('canvas');
+    const userCanvas = document.createElement('canvas');
+    refCanvas.width = userCanvas.width = width;
+    refCanvas.height = userCanvas.height = height;
+    const refCtx = refCanvas.getContext('2d');
+    const userCtx = userCanvas.getContext('2d');
 
-        // Draw user strokes with thicker lines
-        userCtx.fillStyle = 'white';
-        userCtx.fillRect(0, 0, canvas.width, canvas.height);
-        userCtx.strokeStyle = 'black';
-        userCtx.lineWidth = 5; // Increased line width
-        userCtx.lineCap = 'round';
-        userCtx.lineJoin = 'round';
-        
-        strokeHistory.forEach(stroke => {
-            if (stroke.length > 0) {
-                userCtx.beginPath();
-                userCtx.moveTo(stroke[0].x, stroke[0].y);
-                stroke.forEach(point => userCtx.lineTo(point.x, point.y));
-                userCtx.stroke();
-            }
-        });
+    refCtx.fillStyle = 'white';
+    refCtx.fillRect(0, 0, width, height);
+    refCtx.fillStyle = 'black';
 
-        // Get image data
-        const refData = refCtx.getImageData(0, 0, canvas.width, canvas.height).data;
-        const userData = userCtx.getImageData(0, 0, canvas.width, canvas.height).data;
+    const targetArt = targetCharacterDiv.textContent || '';
+    const lines = targetArt.split('\n');
+    let minCol = Infinity;
+    let maxCol = -Infinity;
+    let minRow = Infinity;
+    let maxRow = -Infinity;
 
-        let matchingPixels = 0;
-        let totalTargetPixels = 0;
-        let extraPixels = 0;
-        const tolerance = 12; // Increased tolerance
-
-        // Compare pixels with tolerance
-        for (let y = 0; y < canvas.height; y++) {
-            for (let x = 0; x < canvas.width; x++) {
-                const i = (y * canvas.width + x) * 4;
-                const isRefBlack = refData[i] < 200;
-                const isUserBlack = userData[i] < 200;
-
-                if (isRefBlack) {
-                    totalTargetPixels++;
-                    // Check surrounding pixels with larger area
-                    let matched = false;
-                    for (let dy = -tolerance; dy <= tolerance && !matched; dy++) {
-                        for (let dx = -tolerance; dx <= tolerance && !matched; dx++) {
-                            if (dx * dx + dy * dy <= tolerance * tolerance) { // Circular tolerance area
-                                const ni = ((y + dy) * canvas.width + (x + dx)) * 4;
-                                if (ni >= 0 && ni < userData.length && userData[ni] < 200) {
-                                    matched = true;
-                                    matchingPixels++;
-                                }
-                            }
-                        }
-                    }
-                } else if (isUserBlack) {
-                    // Check if this black pixel is near any reference black pixel
-                    let nearTarget = false;
-                    for (let dy = -tolerance; dy <= tolerance && !nearTarget; dy++) {
-                        for (let dx = -tolerance; dx <= tolerance && !nearTarget; dx++) {
-                            if (dx * dx + dy * dy <= tolerance * tolerance) { // Circular tolerance area
-                                const ni = ((y + dy) * canvas.width + (x + dx)) * 4;
-                                if (ni >= 0 && ni < refData.length && refData[ni] < 200) {
-                                    nearTarget = true;
-                                }
-                            }
-                        }
-                    }
-                    if (!nearTarget) {
-                        extraPixels++;
-                    }
-                }
+    lines.forEach((line, row) => {
+        for (let col = 0; col < line.length; col++) {
+            if (line[col].trim()) {
+                minCol = Math.min(minCol, col);
+                maxCol = Math.max(maxCol, col);
+                minRow = Math.min(minRow, row);
+                maxRow = Math.max(maxRow, row);
             }
         }
-
-        // Calculate base scores
-        const coverage = matchingPixels / (totalTargetPixels || 1);
-        const precision = 1 - Math.min(1, (extraPixels / (totalTargetPixels || 1)));
-        
-        // Apply non-linear scaling to make scores more achievable
-        const scaledCoverage = Math.pow(coverage, 0.7) * 100; // Makes it easier to get higher coverage scores
-        const scaledPrecision = Math.pow(Math.max(0, precision), 0.5) * 100; // More forgiving for precision
-        
-        // Weight the components (more emphasis on coverage)
-        const weightedScore = (scaledCoverage * 0.8 + scaledPrecision * 0.2);
-        
-        // Apply final scaling and bonus points
-        let finalScore = Math.min(100, weightedScore * 1.3); // Boost scores by 30%
-        
-        // Add bonus points for having both good coverage and precision
-        if (coverage > 0.6 && precision > 0.3) {
-            finalScore += 10; // Bonus points for balanced drawing
-        }
-        
-        // Ensure maximum score is 100
-        finalScore = Math.min(100, Math.max(0, finalScore));
-        
-        resolve(Math.round(finalScore));
     });
+
+    if (maxCol === -Infinity) {
+        minCol = 0;
+        maxCol = lines.reduce((acc, line) => Math.max(acc, line.length), 0);
+        minRow = 0;
+        maxRow = lines.length;
+    }
+
+    const effectiveCols = Math.max(1, maxCol - minCol + 1);
+    const effectiveRows = Math.max(1, maxRow - minRow + 1);
+    const cellWidth = width / effectiveCols;
+    const cellHeight = height / effectiveRows;
+    const insetX = (width - cellWidth * effectiveCols) / 2;
+    const insetY = (height - cellHeight * effectiveRows) / 2;
+    const shrinkRatio = 0.8;
+    const fillWidth = Math.max(1, cellWidth * shrinkRatio);
+    const fillHeight = Math.max(1, cellHeight * shrinkRatio);
+    const offsetX = insetX + (cellWidth - fillWidth) / 2;
+    const offsetY = insetY + (cellHeight - fillHeight) / 2;
+
+    lines.forEach((line, row) => {
+        for (let col = 0; col < line.length; col++) {
+            if (!line[col].trim()) continue;
+            const drawX = offsetX + (col - minCol) * cellWidth;
+            const drawY = offsetY + (row - minRow) * cellHeight;
+            refCtx.fillRect(drawX, drawY, fillWidth, fillHeight);
+        }
+    });
+
+    userCtx.fillStyle = 'white';
+    userCtx.fillRect(0, 0, width, height);
+    strokeHistory.forEach(stroke => renderStroke(userCtx, stroke));
+
+    const refData = refCtx.getImageData(0, 0, width, height).data;
+    const userData = userCtx.getImageData(0, 0, width, height).data;
+    const refMask = new Uint8Array(totalPixels);
+    const userMask = new Uint8Array(totalPixels);
+
+    for (let i = 0; i < totalPixels; i++) {
+        const pixelIndex = i * 4;
+        if (refData[pixelIndex + 3] > 128 && refData[pixelIndex] < 200) {
+            refMask[i] = 1;
+        }
+        if (userData[pixelIndex + 3] > 128 && userData[pixelIndex] < 200) {
+            userMask[i] = 1;
+        }
+    }
+
+    const dilationRadius = 6;
+    const dilateMask = (mask) => {
+        const dilated = new Uint8Array(mask.length);
+        for (let y = 0; y < height; y++) {
+            for (let x = 0; x < width; x++) {
+                const index = y * width + x;
+                if (!mask[index]) continue;
+
+                for (let dy = -dilationRadius; dy <= dilationRadius; dy++) {
+                    const ny = y + dy;
+                    if (ny < 0 || ny >= height) continue;
+                    for (let dx = -dilationRadius; dx <= dilationRadius; dx++) {
+                        if (dx * dx + dy * dy > dilationRadius * dilationRadius) continue;
+                        const nx = x + dx;
+                        if (nx < 0 || nx >= width) continue;
+                        dilated[ny * width + nx] = 1;
+                    }
+                }
+            }
+        }
+        return dilated;
+    };
+
+    const userDilated = dilateMask(userMask);
+    const refDilated = dilateMask(refMask);
+
+    let matchedForRecall = 0;
+    let matchedForPrecision = 0;
+    let refCount = 0;
+    let userCount = 0;
+
+    for (let i = 0; i < totalPixels; i++) {
+        if (refMask[i]) {
+            refCount++;
+            if (userDilated[i]) {
+                matchedForRecall++;
+            }
+        }
+        if (userMask[i]) {
+            userCount++;
+            if (refDilated[i]) {
+                matchedForPrecision++;
+            }
+        }
+    }
+
+    const recall = refCount === 0 ? 0 : matchedForRecall / refCount;
+    const precision = userCount === 0 ? 0 : matchedForPrecision / userCount;
+    const f1Score = (precision + recall) === 0 ? 0 : (2 * precision * recall) / (precision + recall);
+    const score = Math.round(clamp(f1Score * 100, 0, 100));
+
+    return {
+        score,
+        precision,
+        recall,
+        f1Score,
+        refMask,
+        userMask,
+        width,
+        height,
+        missingCount: Math.max(0, refCount - matchedForRecall),
+        extraCount: Math.max(0, userCount - matchedForPrecision),
+        refPixelCount: refCount,
+        userPixelCount: userCount
+    };
 }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,64 +1,125 @@
 body {
     font-family: 'Segoe UI', Roboto, sans-serif;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    min-height: 100vh;
     margin: 0;
-    background-image: url('./images/background.jpg');
-    background-size: cover;
-    background-position: center;
-    background-attachment: fixed;
+    min-height: 100vh;
+    background:
+        radial-gradient(120% 120% at 10% 5%, rgba(56, 189, 248, 0.35), transparent 55%),
+        radial-gradient(90% 120% at 85% 8%, rgba(244, 114, 182, 0.32), transparent 60%),
+        linear-gradient(135deg, #0f172a 0%, #1e293b 48%, #0b1120 100%);
     font-display: swap;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: clamp(12px, 4vw, 36px) clamp(10px, 5vw, 48px);
+    box-sizing: border-box;
+    color: #0f172a;
+    position: relative;
+    overflow-x: hidden;
+}
+
+body::before,
+body::after {
+    content: "";
+    position: fixed;
+    width: clamp(220px, 42vw, 520px);
+    height: clamp(220px, 42vw, 520px);
+    border-radius: 50%;
+    filter: blur(80px);
+    opacity: 0.85;
+    z-index: -2;
+    pointer-events: none;
+}
+
+body::before {
+    top: -140px;
+    left: -100px;
+    background: radial-gradient(circle at center, rgba(59, 130, 246, 0.65), rgba(59, 130, 246, 0));
+}
+
+body::after {
+    bottom: -160px;
+    right: -120px;
+    background: radial-gradient(circle at center, rgba(236, 72, 153, 0.6), rgba(236, 72, 153, 0));
 }
 
 .container {
     text-align: center;
-    padding: 20px;  
-    max-width: 1200px;  
-    width: 98%;
-    margin: 10px auto;  
-    background-color: white;
-    border-radius: 20px;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-    backdrop-filter: blur(10px);
-    background-color: rgba(255, 255, 255, 0.9);
+    padding: clamp(18px, 3vw, 32px);
+    max-width: 1080px;
+    width: min(100%, 1024px);
+    margin: 0 auto;
+    background: rgba(255, 255, 255, 0.16);
+    border-radius: 28px;
+    border: 1px solid rgba(255, 255, 255, 0.32);
+    box-shadow:
+        0 40px 80px -40px rgba(8, 47, 73, 0.65),
+        inset 0 1px 0 rgba(255, 255, 255, 0.35),
+        inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+    backdrop-filter: blur(28px) saturate(150%);
+    position: relative;
+    overflow: hidden;
+}
+
+.container::before {
+    content: "";
+    position: absolute;
+    inset: 12px;
+    border-radius: 24px;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    pointer-events: none;
+    mix-blend-mode: screen;
+    opacity: 0.45;
 }
 
 .header-content {
     display: flex;
-    align-items: flex-start;
+    flex-wrap: wrap;
+    align-items: stretch;
     justify-content: center;
-    gap: 20px;
-    margin-bottom: 15px;
+    gap: clamp(16px, 4vw, 32px);
+    margin-bottom: clamp(16px, 4vw, 32px);
 }
 
 h1 {
     color: #2c3e50;
-    margin-bottom: 25px;
-    font-size: 2.2em;
+    margin-bottom: clamp(12px, 3vw, 24px);
+    font-size: clamp(1.8rem, 4vw, 2.4rem);
     font-weight: 600;
+}
+
+.main-content {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 360px);
+    gap: clamp(20px, 5vw, 36px);
+    align-items: start;
+}
+
+.drawing-section {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    align-items: center;
 }
 
 .character-container {
     position: relative;
-    margin: 15px auto;  /* 減少邊距 */
-    width: 350px;  /* 稍微縮小畫布 */
-    height: 350px;
-    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.08);
-    border-radius: 15px;
+    width: min(90vw, 420px);
+    aspect-ratio: 1 / 1;
+    box-shadow: 0 28px 48px -32px rgba(15, 23, 42, 0.68);
+    border-radius: 22px;
     overflow: hidden;
+    background: rgba(255, 255, 255, 0.18);
+    border: 1px solid rgba(255, 255, 255, 0.32);
+    backdrop-filter: blur(20px) saturate(160%);
 }
 
 .target-character {
     position: absolute;
-    top: 0;
-    left: 0;
-    width: 350px;
-    height: 350px;
-    font-size: 10px;
+    inset: 0;
+    font-family: 'Fira Code', 'Courier New', monospace;
+    color: rgba(15, 23, 42, 0.25);
+    font-size: clamp(6px, 1.6vw, 11px);
     line-height: 1;
-    color: #ddd;
     user-select: none;
     pointer-events: none;
     overflow: hidden;
@@ -70,87 +131,131 @@ h1 {
 }
 
 canvas {
-    border: 2px solid #e0e0e0;
-    border-radius: 15px;
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    border-radius: 22px;
     cursor: crosshair;
-    background: #ffffff;
-    width: 350px;
-    height: 350px;
+    background: rgba(255, 255, 255, 0.28);
+    width: 100%;
+    height: 100%;
     touch-action: none;
+    display: block;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
 }
 
-#feedback {
-    margin: 10px 0;  /* 減少邊距 */
-    font-size: 1.2em;
-    font-weight: 500;
-    padding: 10px;
-    border-radius: 10px;
-    transition: all 0.3s ease;
+.analysis-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.25s ease;
+}
+
+.analysis-layer.visible {
+    opacity: 0.75;
+}
+
+.canvas-hint {
+    margin: 0;
+    font-size: clamp(0.9rem, 3vw, 1rem);
+    color: rgba(15, 23, 42, 0.68);
+    max-width: min(90vw, 420px);
+    line-height: 1.4;
+}
+
+.controls-section {
+    width: 100%;
+    background: rgba(255, 255, 255, 0.14);
+    padding: clamp(18px, 3vw, 26px);
+    border-radius: 22px;
+    border: 1px solid rgba(255, 255, 255, 0.28);
+    box-shadow: 0 24px 50px -30px rgba(15, 23, 42, 0.65);
+    backdrop-filter: blur(22px) saturate(150%);
 }
 
 .controls {
+    display: grid;
+    gap: 16px;
+}
+
+.control-group,
+.button-group {
     display: flex;
+    gap: 12px;
     justify-content: center;
-    gap: 10px;
-    margin-top: 15px;  /* 減少邊距 */
     flex-wrap: wrap;
-    flex-direction: column;
-    align-items: center;
+    padding: 12px;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.12);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
 }
 
 .color-picker {
-    width: 60px;
-    height: 40px;
-    padding: 5px;
-    border: 2px solid #e0e0e0;
-    border-radius: 10px;
+    width: 70px;
+    height: 46px;
+    padding: 4px;
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    border-radius: 14px;
     cursor: pointer;
+    background: rgba(255, 255, 255, 0.4);
+    box-shadow: 0 8px 16px rgba(15, 23, 42, 0.18);
 }
 
 .line-width {
-    width: 60px;
-    height: 40px;
-    padding: 5px 10px;
-    border: 2px solid #e0e0e0;
-    border-radius: 10px;
+    width: 80px;
+    height: 46px;
+    padding: 6px 10px;
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    border-radius: 14px;
     font-size: 16px;
     text-align: center;
+    background: rgba(255, 255, 255, 0.4);
+    color: #0f172a;
+    box-shadow: 0 8px 16px rgba(15, 23, 42, 0.18);
 }
 
 button {
-    padding: 12px 25px;
+    padding: 12px 24px;
     font-size: 16px;
     border: none;
-    border-radius: 10px;
+    border-radius: 14px;
     cursor: pointer;
-    transition: all 0.3s ease;
-    font-weight: 500;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+    font-weight: 600;
     min-height: 44px;
     min-width: 44px;
-    margin: 5px;
+    margin: 0;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.28), rgba(255, 255, 255, 0.08));
+    color: #0f172a;
+    border: 1px solid rgba(255, 255, 255, 0.28);
+    box-shadow: 0 12px 25px -12px rgba(15, 23, 42, 0.55);
 }
 
 #undoButton {
-    background-color: #3498db;
-    color: white;
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.85), rgba(56, 189, 248, 0.65));
+    color: #f8fafc;
 }
 
 #resetButton {
-    background-color: #e74c3c;
-    color: white;
+    background: linear-gradient(135deg, rgba(239, 68, 68, 0.85), rgba(251, 113, 133, 0.65));
+    color: #f8fafc;
 }
 
 button:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
+    transform: translateY(-1px);
+    box-shadow: 0 16px 30px -14px rgba(15, 23, 42, 0.55);
+    filter: brightness(1.03);
+}
+
+button:disabled {
+    filter: saturate(0.6) brightness(0.95);
+    box-shadow: none;
 }
 
 #score {
-    font-size: 28px;
-    margin-top: 10px;  /* 減少邊距 */
-    font-weight: 600;
-    color: #2c3e50;
-    text-shadow: 1px 1px 2px rgba(0,0,0,0.1);
+    font-size: clamp(1.5rem, 5vw, 2rem);
+    font-weight: 700;
+    color: #0f172a;
+    text-shadow: 0 6px 18px rgba(15, 23, 42, 0.16);
     opacity: 0;
     transition: opacity 0.3s ease;
 }
@@ -159,24 +264,245 @@ button:hover {
     opacity: 1;
 }
 
-.target-character {
-    font-family: monospace;
-    color: #95a5a6;
+.score-display {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 4px 12px;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.22);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
 }
 
-.game-description {
-    color: #666;
-    margin: 20px auto;
-    max-width: 600px;
-    line-height: 1.6;
-    font-size: 1.1em;
+.status-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    align-items: stretch;
+    background: rgba(255, 255, 255, 0.16);
+    border-radius: 20px;
+    padding: 18px;
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.score-overview {
+    display: flex;
+    gap: 20px;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+.gauge {
+    position: relative;
+    width: 140px;
+    height: 140px;
+}
+
+.gauge svg {
+    width: 100%;
+    height: 100%;
+    transform: rotate(-90deg);
+}
+
+.gauge-track {
+    fill: none;
+    stroke: rgba(148, 163, 184, 0.35);
+    stroke-width: 12;
+}
+
+.gauge-progress {
+    fill: none;
+    stroke: #38bdf8;
+    stroke-width: 12;
+    stroke-linecap: round;
+    stroke-dasharray: 327;
+    stroke-dashoffset: 327;
+    transition: stroke-dashoffset 0.4s ease;
+}
+
+.gauge-label {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.8rem;
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.gauge-caption {
+    margin: 6px 0 0;
+    font-size: 0.9rem;
+    text-align: center;
+    color: rgba(15, 23, 42, 0.6);
+}
+
+.score-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    align-items: center;
+}
+
+.feedback-display {
+    font-size: clamp(1rem, 3.2vw, 1.1rem);
+    font-weight: 500;
+    text-align: center;
+    min-height: 1.6em;
+    color: rgba(15, 23, 42, 0.82);
+}
+
+.metric-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 14px;
+}
+
+.metric {
+    background: rgba(255, 255, 255, 0.22);
+    border-radius: 14px;
+    padding: 12px 14px;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.16);
+    text-align: center;
+    backdrop-filter: blur(16px) saturate(150%);
+}
+
+.metric-label {
+    display: block;
+    font-size: 0.9rem;
+    color: rgba(15, 23, 42, 0.65);
+}
+
+.metric-value {
+    display: block;
+    font-size: 1.2rem;
+    font-weight: 600;
+    margin-top: 4px;
+    color: #0f172a;
+}
+
+.guidance-btn {
+    width: 100%;
+    margin-top: 12px;
+    background: linear-gradient(135deg, rgba(139, 92, 246, 0.9), rgba(129, 140, 248, 0.7));
+    color: #f8fafc;
+}
+
+.guidance-btn:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+    background: linear-gradient(135deg, rgba(165, 180, 252, 0.55), rgba(129, 140, 248, 0.35));
+}
+
+.replay-btn {
+    width: 100%;
+    background: linear-gradient(135deg, rgba(253, 186, 116, 0.9), rgba(251, 146, 60, 0.75));
+    color: #2c1810;
+}
+
+.replay-btn:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+    background: linear-gradient(135deg, rgba(253, 213, 154, 0.6), rgba(250, 204, 141, 0.45));
+}
+
+.analysis-summary {
+    margin-top: 8px;
+    font-size: 0.9rem;
+    color: rgba(15, 23, 42, 0.75);
+    text-align: center;
+    min-height: 1.4em;
+}
+
+.session-stats {
+    background: rgba(255, 255, 255, 0.22);
+    border-radius: 16px;
+    padding: 14px;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.16);
+    display: grid;
+    gap: 12px;
+}
+
+.session-stats-title {
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: rgba(15, 23, 42, 0.85);
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+}
+
+.session-stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 12px;
+}
+
+.session-stat {
+    background: rgba(255, 255, 255, 0.26);
+    border-radius: 14px;
+    padding: 12px 14px;
+    text-align: center;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
+    backdrop-filter: blur(14px) saturate(150%);
+}
+
+.session-stat-label {
+    display: block;
+    font-size: 0.85rem;
+    color: #4f5b66;
+}
+
+.session-stat-value {
+    display: block;
+    font-size: 1.2rem;
+    font-weight: 600;
+    margin-top: 4px;
+    color: #0f172a;
+}
+
+.session-stats-placeholder {
+    display: none;
+    margin: 0;
+    font-size: 0.85rem;
+    color: rgba(15, 23, 42, 0.65);
+    text-align: center;
+}
+
+.session-stats.is-empty .session-stats-grid {
+    display: none;
+}
+
+.session-stats.is-empty .session-stats-placeholder.active {
+    display: block;
+}
+
+.session-stats.is-empty .session-stat-value {
+    color: rgba(15, 23, 42, 0.45);
+}
+
+.analysis-layer.replay-hidden {
+    opacity: 0 !important;
+}
+
+canvas.is-replaying {
+    cursor: progress;
+}
+
+.target-character {
+    font-family: monospace;
 }
 
 .submit-btn {
-    background-color: #2ecc71;
-    margin: 10px;  
-    padding: 15px 30px;
+    background: linear-gradient(135deg, rgba(34, 197, 94, 0.9), rgba(74, 222, 128, 0.7));
+    color: #042f1a;
     width: 100%;
+    padding: 14px 24px;
+    letter-spacing: 0.5px;
 }
 
 .game-over {
@@ -191,33 +517,38 @@ button:hover {
 }
 
 .story-container {
-    background: rgba(255, 255, 255, 0.95);
-    padding: 15px;
-    border-radius: 15px;
-    margin: 0;  
+    background: rgba(255, 255, 255, 0.18);
+    padding: 18px;
+    border-radius: 18px;
+    margin: 0;
     max-width: none;
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 24px 40px -28px rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.28);
+    backdrop-filter: blur(20px) saturate(150%);
     flex-grow: 1;
 }
 
 .dialogue {
     text-align: left;
-    padding: 5px;  
-    margin: 3px 0;  
-    border-radius: 10px;
-    font-size: 0.95em; 
+    padding: 8px 10px;
+    margin: 6px 0;
+    border-radius: 12px;
+    font-size: 0.95em;
+    background: rgba(255, 255, 255, 0.14);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
 }
 
 .speaker {
     font-weight: bold;
-    color: #2c3e50;
+    color: rgba(15, 23, 42, 0.85);
 }
 
 .title-image {
-    max-width: 250px;  
-    margin: 0; 
-    border-radius: 10px;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    max-width: 250px;
+    margin: 0;
+    border-radius: 16px;
+    box-shadow: 0 24px 38px -24px rgba(15, 23, 42, 0.65);
+    border: 1px solid rgba(255, 255, 255, 0.28);
     flex-shrink: 0;
 }
 
@@ -286,85 +617,30 @@ button:hover {
     bottom: 20px;
     right: 20px;
     padding: 10px 20px;
-    background: rgba(0, 0, 0, 0.8);
-    color: white;
+    background: linear-gradient(135deg, rgba(15, 23, 42, 0.75), rgba(30, 64, 175, 0.65));
+    color: #e2e8f0;
     text-decoration: none;
-    border-radius: 20px;
+    border-radius: 24px;
     display: flex;
     align-items: center;
     gap: 8px;
     font-size: 14px;
     transition: all 0.3s ease;
     z-index: 1000;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    box-shadow: 0 18px 34px -20px rgba(15, 23, 42, 0.75);
 }
 
 .github-link:hover {
     transform: translateY(-3px);
-    box-shadow: 0 5px 15px rgba(0,0,0,0.2);
-    background: rgba(0, 0, 0, 0.9);
+    box-shadow: 0 20px 40px -20px rgba(15, 23, 42, 0.85);
+    background: linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(30, 64, 175, 0.75));
 }
 
 .github-icon {
     width: 20px;
     height: 20px;
     fill: white;
-}
-
-.main-content {
-    display: flex;
-    gap: 20px;
-    justify-content: center;
-    align-items: flex-start;
-    margin-top: 20px;
-}
-
-.drawing-section {
-    flex: 0 0 auto;
-}
-
-.controls-section {
-    flex: 1;
-    max-width: 400px;
-    background: rgba(255, 255, 255, 0.95);
-    padding: 20px;
-    border-radius: 15px;
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
-    width: 100%;
-}
-
-.controls {
-    flex-direction: column;
-    align-items: center;
-    gap: 15px;
-    margin-top: 0;
-}
-
-.control-group {
-    display: flex;
-    gap: 10px;
-    justify-content: center;
-    width: 100%;
-    flex-wrap: wrap;
-}
-
-.button-group {
-    display: flex;
-    gap: 10px;
-    justify-content: center;
-    width: 100%;
-    flex-wrap: wrap;
-}
-
-.submit-btn {
-    width: 100%;
-    margin: 15px 0;
-}
-
-#feedback {
-    margin: 15px 0;
-    padding: 10px;
-    border-radius: 8px;
-    background: rgba(255, 255, 255, 0.8);
 }
 
 .message-overlay {
@@ -379,19 +655,17 @@ button:hover {
     opacity: 0;
     pointer-events: none; /* Prevent blocking interactions */
     transition: opacity 0.3s ease;
-    background: rgba(255, 255, 255, 0.9);
-    padding: 15px;
-    border-radius: 10px;
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+    background: rgba(255, 255, 255, 0.22);
+    padding: 18px;
+    border-radius: 18px;
+    box-shadow: 0 24px 36px -22px rgba(15, 23, 42, 0.55);
     bottom: 20px;
     top: auto;
     transform: translateX(-50%);
     width: 90%;
     max-width: 400px;
-    background: rgba(255, 255, 255, 0.95);
-    border-radius: 15px;
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
-    padding: 15px;
+    border: 1px solid rgba(255, 255, 255, 0.28);
+    backdrop-filter: blur(20px) saturate(160%);
     z-index: 1002;
 }
 
@@ -448,18 +722,19 @@ button:hover {
     top: 20px;
     right: 20px;
     padding: 10px 20px;
-    background: rgba(0, 0, 0, 0.8);
-    color: white;
-    border: none;
-    border-radius: 20px;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0.18));
+    color: #0f172a;
+    border: 1px solid rgba(255, 255, 255, 0.32);
+    border-radius: 24px;
     cursor: pointer;
     z-index: 1000;
     transition: all 0.3s ease;
+    box-shadow: 0 14px 30px -18px rgba(15, 23, 42, 0.6);
 }
 
 .language-switch:hover {
     transform: translateY(-2px);
-    background: rgba(0, 0, 0, 0.9);
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0.28));
 }
 
 [lang="en"], [lang="zh"] {
@@ -470,63 +745,78 @@ button:hover {
     display: block;
 }
 
+@media (max-width: 1024px) {
+    .main-content {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .controls-section {
+        max-width: 520px;
+        margin: 0 auto;
+    }
+}
+
 @media (max-width: 768px) {
+    body {
+        padding: clamp(12px, 3vh, 28px) clamp(8px, 6vw, 28px);
+    }
+
     .container {
-        padding: 10px;
-        width: 95%;
+        padding: clamp(16px, 5vw, 28px);
     }
 
     .header-content {
         flex-direction: column;
-        align-items: center;
     }
 
     .title-image {
-        max-width: 200px;
+        max-width: min(70vw, 220px);
+        margin: 0 auto;
     }
 
-    .main-content {
-        flex-direction: column;
-        align-items: center;
-    }
-
-    .controls-section {
-        width: 100%;
-    }
-
-    .character-container {
-        width: 300px;
-        height: 300px;
-    }
-
-    canvas {
-        width: 300px;
-        height: 300px;
-    }
-
-    .target-character {
-        width: 300px;
-        height: 300px;
-    }
-
-    h1 {
-        font-size: 1.8em;
+    .canvas-hint {
+        text-align: center;
     }
 }
 
-/* Fix language switch positioning on mobile */
-@media (max-width: 480px) {
+@media (max-width: 540px) {
+    .character-container {
+        width: min(100%, 360px);
+    }
+
+    .controls-section {
+        padding: clamp(14px, 4vw, 20px);
+    }
+
+    .control-group,
+    .button-group {
+        gap: 10px;
+    }
+
+    .controls-section button {
+        width: 100%;
+    }
+
+    .score-overview {
+        flex-direction: column;
+    }
+
+    .gauge {
+        width: 120px;
+        height: 120px;
+    }
+
     .language-switch {
-        top: 10px;
-        right: 10px;
-        padding: 8px 15px;
+        top: 12px;
+        right: 12px;
+        padding: 8px 16px;
         font-size: 14px;
     }
 
     .github-link {
-        bottom: 10px;
-        right: 10px;
-        padding: 8px 15px;
+        bottom: 12px;
+        right: 12px;
+        padding: 8px 16px;
         font-size: 12px;
     }
 }

--- a/index.html
+++ b/index.html
@@ -19,7 +19,6 @@
     <link rel="apple-touch-icon" href="./assets/images/icon.png">
     <link rel="stylesheet" href="./assets/styles.css">
     <script src="./assets/script.js" defer></script>
-    <script src="./assets/tfjs@latest.js"></script>
 </head>
 <body>
     <button class="language-switch" onclick="toggleLanguage()">中文 / English</button>
@@ -27,7 +26,7 @@
     <div class="container">
         <h1 class="rainbow-title" lang="en">Draw the Chinese Word "Sir"</h1>
         <h1 class="rainbow-title" lang="zh">點寫方中sir</h1>
-        
+
         <div class="header-content">
             <img src="./assets/images/title-image.jpg" alt="Mr. Fong" class="title-image">
             <div class="story-container">
@@ -76,9 +75,12 @@
                 <div class="character-container">
                     <div id="targetCharacter" class="target-character"></div>
                     <canvas id="drawingCanvas" width="400" height="400"></canvas>
+                    <canvas id="analysisCanvas" width="400" height="400" class="analysis-layer" aria-hidden="true"></canvas>
                 </div>
+                <p class="canvas-hint" lang="en">Trace the strokes with your finger or mouse to match the sample.</p>
+                <p class="canvas-hint" lang="zh">用手指或滑鼠跟住樣板嘅筆劃慢慢描。</p>
             </div>
-            
+
             <div class="controls-section">
                 <div class="controls">
                     <div class="control-group">
@@ -91,8 +93,68 @@
                     </div>
                     <button id="submitButtonZh" class="submit-btn" lang="zh">提交</button>
                     <button id="submitButtonEn" class="submit-btn" lang="en">Submit</button>
-                    <div id="feedback"></div>
-                    <div id="score">得分: 0%</div>
+                    <div class="status-panel">
+                        <div class="score-overview">
+                            <div class="gauge" role="img" aria-labelledby="gaugeLabel">
+                                <svg viewBox="0 0 120 120">
+                                    <circle class="gauge-track" cx="60" cy="60" r="52"></circle>
+                                    <circle class="gauge-progress" id="gaugeProgress" cx="60" cy="60" r="52"></circle>
+                                </svg>
+                                <div class="gauge-label" id="gaugeLabel">0%</div>
+                                <p class="gauge-caption" lang="en">Overall accuracy</p>
+                                <p class="gauge-caption" lang="zh">整體準確度</p>
+                            </div>
+                            <div class="score-summary">
+                                <div id="score" class="score-display">得分: 0%</div>
+                                <div id="feedback" class="feedback-display"></div>
+                            </div>
+                        </div>
+                        <div class="metric-grid">
+                            <div class="metric">
+                                <span class="metric-label" lang="en">Stroke coverage</span>
+                                <span class="metric-label" lang="zh">覆蓋率</span>
+                                <span class="metric-value" id="coverageValue">0%</span>
+                            </div>
+                            <div class="metric">
+                                <span class="metric-label" lang="en">Line cleanliness</span>
+                                <span class="metric-label" lang="zh">線條整潔度</span>
+                                <span class="metric-value" id="precisionValue">0%</span>
+                            </div>
+                        </div>
+                        <div class="session-stats" id="sessionStats">
+                            <div class="session-stats-title">
+                                <span lang="en">Practice tracker</span>
+                                <span lang="zh">練習追蹤</span>
+                            </div>
+                            <p class="session-stats-placeholder" lang="en">Complete a round to start tracking your progress.</p>
+                            <p class="session-stats-placeholder" lang="zh">完成一局先開始記錄進度。</p>
+                            <div class="session-stats-grid">
+                                <div class="session-stat">
+                                    <span class="session-stat-label" lang="en">Best accuracy</span>
+                                    <span class="session-stat-label" lang="zh">最高準確度</span>
+                                    <span class="session-stat-value" id="bestAccuracyValue">0%</span>
+                                </div>
+                                <div class="session-stat">
+                                    <span class="session-stat-label" lang="en">Average accuracy</span>
+                                    <span class="session-stat-label" lang="zh">平均準確度</span>
+                                    <span class="session-stat-value" id="averageAccuracyValue">0%</span>
+                                </div>
+                                <div class="session-stat">
+                                    <span class="session-stat-label" lang="en">Attempts</span>
+                                    <span class="session-stat-label" lang="zh">練習次數</span>
+                                    <span class="session-stat-value" id="attemptCountValue">0</span>
+                                </div>
+                                <div class="session-stat">
+                                    <span class="session-stat-label" lang="en">Hot streak ≥70% (current / best)</span>
+                                    <span class="session-stat-label" lang="zh">連勝 ≥70%（現時 / 最長）</span>
+                                    <span class="session-stat-value" id="streakValue">0 / 0</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <button id="replayButton" class="replay-btn" data-label-en="Replay my strokes" data-label-zh="重播我嘅筆畫">Replay my strokes</button>
+                    <button id="toggleOverlay" class="guidance-btn" data-label-en="Show guidance overlay" data-label-zh="顯示指引覆蓋層" data-hide-label-en="Hide guidance overlay" data-hide-label-zh="隱藏指引覆蓋層">Show guidance overlay</button>
+                    <div id="analysisSummary" class="analysis-summary" aria-live="polite"></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- rework stroke capture to store timestamped points and rebuild the replay loop around a timeline-aware animator so saved drawings play back smoothly and respect pauses
- reset live stats and feedback handling, including placeholder toggles and updated palette, to align with the refreshed interface
- restyle the layout with glassmorphism gradients, frosted panels, and gradient controls for a fluid “liquid glass” appearance on desktop and mobile

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68ca43498034832bbd4d92d4da22fa5d